### PR TITLE
Fix: Disable animations when dropping items in grid

### DIFF
--- a/lib/nomo_pagegrid.dart
+++ b/lib/nomo_pagegrid.dart
@@ -257,7 +257,7 @@ class _NomoPageGrid extends StatefulWidget {
 
 class _NomoPageGridState extends State<_NomoPageGrid> implements PageGridControllerState {
   final GlobalKey _stackKey = GlobalKey();
-  
+
   late final PageGridNotifier pageGridNotifier = PageGridNotifier(
     viewportWidth: widget.width,
     viewportHeight: widget.height,
@@ -544,7 +544,7 @@ class _InnerPageGridItemState extends State<InnerPageGridItem> {
             _ => Offset.zero,
           },
           child: AnimatedContainer(
-            duration: disableAnimation ? Duration.zero : const Duration(milliseconds: 200),
+            duration: const Duration(milliseconds: 200),
             curve: Curves.ease,
             transform: switch (widget.state) {
               EvadingPageSpot evading => Matrix4.translationValues(
@@ -564,8 +564,9 @@ class _InnerPageGridItemState extends State<InnerPageGridItem> {
 
             // Convert global offset to local coordinates for consistency
             Offset localOffset = details.offset;
-            
-            final RenderBox? gridStackBox = widget.gridStackKey.currentContext?.findRenderObject() as RenderBox?;
+
+            final RenderBox? gridStackBox =
+                widget.gridStackKey.currentContext?.findRenderObject() as RenderBox?;
             if (gridStackBox != null && gridStackBox.attached) {
               localOffset = gridStackBox.globalToLocal(details.offset);
             }
@@ -585,8 +586,9 @@ class _InnerPageGridItemState extends State<InnerPageGridItem> {
             // Convert global offset to local coordinates relative to the grid
             // Use the grid Stack's RenderBox for accurate coordinate conversion
             Offset localOffset = details.offset;
-            
-            final RenderBox? gridStackBox = widget.gridStackKey.currentContext?.findRenderObject() as RenderBox?;
+
+            final RenderBox? gridStackBox =
+                widget.gridStackKey.currentContext?.findRenderObject() as RenderBox?;
             if (gridStackBox != null && gridStackBox.attached) {
               localOffset = gridStackBox.globalToLocal(details.offset);
             }
@@ -659,7 +661,12 @@ class PageGridItem extends StatelessWidget {
       builder: (context, itemState, placeholer) {
         return switch (itemState) {
           EmptyPageSpot() => placeholer!,
-          ItemPageSpot itemState => InnerPageGridItem(itemState, index, pageGridNotifier, gridStackKey),
+          ItemPageSpot itemState => InnerPageGridItem(
+            itemState,
+            index,
+            pageGridNotifier,
+            gridStackKey,
+          ),
         };
       },
       child: DragTarget<int>(

--- a/lib/nomo_pagegrid.dart
+++ b/lib/nomo_pagegrid.dart
@@ -530,8 +530,6 @@ class InnerPageGridItem extends StatefulWidget {
 }
 
 class _InnerPageGridItemState extends State<InnerPageGridItem> {
-  bool disableAnimation = false;
-
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
@@ -544,7 +542,7 @@ class _InnerPageGridItemState extends State<InnerPageGridItem> {
             _ => Offset.zero,
           },
           child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
+            duration: widget.state.isDropping ? Duration.zero : const Duration(milliseconds: 200),
             curve: Curves.ease,
             transform: switch (widget.state) {
               EvadingPageSpot evading => Matrix4.translationValues(
@@ -560,8 +558,6 @@ class _InnerPageGridItemState extends State<InnerPageGridItem> {
 
         return DragTarget<int>(
           onAcceptWithDetails: (details) {
-            disableAnimation = true;
-
             // Convert global offset to local coordinates for consistency
             Offset localOffset = details.offset;
 
@@ -572,13 +568,6 @@ class _InnerPageGridItemState extends State<InnerPageGridItem> {
             }
 
             widget.pageGridNotifier.onItemReceive(widget.index, details.data, localOffset);
-
-            Future.delayed(
-              Duration(milliseconds: 200),
-              () {
-                disableAnimation = false;
-              },
-            );
           },
           onMove: (details) {
             if (widget.index == details.data) return;
@@ -716,8 +705,9 @@ final class EmptyPageSpot extends PageSpotState {}
 
 final class ItemPageSpot extends PageSpotState {
   final Widget item;
+  final bool isDropping;
 
-  const ItemPageSpot(this.item);
+  const ItemPageSpot(this.item, {this.isDropping = false});
 }
 
 final class EvadingPageSpot extends ItemPageSpot {
@@ -726,7 +716,7 @@ final class EvadingPageSpot extends ItemPageSpot {
 
   final Offset? wobble;
 
-  const EvadingPageSpot(super.item, this.dx, this.dy, this.wobble);
+  const EvadingPageSpot(super.item, this.dx, this.dy, this.wobble, {super.isDropping = false});
 }
 
 enum PushDirection {
@@ -875,9 +865,29 @@ final class PageGridNotifier {
         pushResult[oldPosition] == newPosition &&
         pushResult[newPosition] == oldPosition) {
       final itemAtNewPosition = notifierMap[newPosition]!.value;
-      notifierMap[newPosition]!.value = draggedItem;
-      notifierMap[oldPosition]!.value = itemAtNewPosition;
+
+      // Mark both items as dropping to prevent animation
+      if (draggedItem is ItemPageSpot) {
+        notifierMap[newPosition]!.value = ItemPageSpot(draggedItem.item, isDropping: true);
+      }
+      if (itemAtNewPosition is ItemPageSpot) {
+        notifierMap[oldPosition]!.value = ItemPageSpot(itemAtNewPosition.item, isDropping: true);
+      }
+
       onItemsChanged();
+
+      // Clear isDropping flag after animation duration
+      Future.delayed(const Duration(milliseconds: 200), () {
+        if (notifierMap[newPosition]!.value is ItemPageSpot) {
+          final item = notifierMap[newPosition]!.value as ItemPageSpot;
+          notifierMap[newPosition]!.value = ItemPageSpot(item.item, isDropping: false);
+        }
+        if (notifierMap[oldPosition]!.value is ItemPageSpot) {
+          final item = notifierMap[oldPosition]!.value as ItemPageSpot;
+          notifierMap[oldPosition]!.value = ItemPageSpot(item.item, isDropping: false);
+        }
+      });
+
       return;
     }
 
@@ -890,18 +900,32 @@ final class PageGridNotifier {
       }
     }
 
-    // Apply moves in the correct order
+    // Track all affected indices for clearing isDropping flag later
+    final affectedIndices = <int>{};
+
+    // Apply moves in the correct order with isDropping flag
     for (final entry in pushResult.entries) {
       final fromIndex = entry.key;
       final toIndex = entry.value;
       if (fromIndex != oldPosition) {
         // Don't move the dragged item yet
-        notifierMap[toIndex]!.value = itemsToMove[fromIndex]!;
+        final itemToMove = itemsToMove[fromIndex]!;
+        if (itemToMove is ItemPageSpot) {
+          notifierMap[toIndex]!.value = ItemPageSpot(itemToMove.item, isDropping: true);
+          affectedIndices.add(toIndex);
+        } else {
+          notifierMap[toIndex]!.value = itemToMove;
+        }
       }
     }
 
-    // Place the dragged item at target position
-    notifierMap[newPosition]!.value = draggedItem;
+    // Place the dragged item at target position with isDropping flag
+    if (draggedItem is ItemPageSpot) {
+      notifierMap[newPosition]!.value = ItemPageSpot(draggedItem.item, isDropping: true);
+      affectedIndices.add(newPosition);
+    } else {
+      notifierMap[newPosition]!.value = draggedItem;
+    }
 
     // Clear the old position if it's not being used by another item
     if (!pushResult.containsValue(oldPosition)) {
@@ -909,6 +933,18 @@ final class PageGridNotifier {
     }
 
     onItemsChanged();
+
+    // Clear isDropping flag after animation duration
+    if (affectedIndices.isNotEmpty) {
+      Future.delayed(const Duration(milliseconds: 200), () {
+        for (final index in affectedIndices) {
+          if (notifierMap[index]!.value is ItemPageSpot) {
+            final item = notifierMap[index]!.value as ItemPageSpot;
+            notifierMap[index]!.value = ItemPageSpot(item.item, isDropping: false);
+          }
+        }
+      });
+    }
   }
 
   // Used for debouncing animation of Displacement


### PR DESCRIPTION
## Summary
- Prevents unwanted animations when items are dropped in the grid
- Fixes the issue where dragged items and evading items animate from their old positions
- Implements a state-based approach to selectively disable animations during drop operations

## Problem
Currently, when `onItemReceive` is called after dropping an item:
1. The dragged item and evading items (excluding the last item in the push chain) animate from their old positions
2. This happens because `AnimatedContainer` transitions from `EvadingPageSpot` state back to normal `ItemPageSpot` state
3. The existing `disableAnimation` flag in `_InnerPageGridItemState` is not connected to the animation logic

## Architecture Overview

### Solution: State-Based Animation Control
Add an `isDropping` flag to the PageSpotState hierarchy that AnimatedContainer can check to determine whether to animate.

### Components Modified:
1. **PageSpotState Classes** (lib/nomo_pagegrid.dart:706-730)
   - Add `isDropping` property to `ItemPageSpot` and `EvadingPageSpot`
   - Preserve flag through state transitions

2. **InnerPageGridItem Widget** (lib/nomo_pagegrid.dart:520-642)
   - Modify AnimatedContainer to check `isDropping` flag
   - Use `Duration.zero` when dropping, normal duration otherwise
   - Remove unused `disableAnimation` local state

3. **PageGridNotifier** (lib/nomo_pagegrid.dart:849-912)
   - Update `onItemReceive` to mark affected items with `isDropping = true`
   - Schedule flag removal after drop completes

## Technical Design

### State Classes Update:
```dart
final class ItemPageSpot extends PageSpotState {
  final Widget item;
  final bool isDropping;
  
  const ItemPageSpot(this.item, {this.isDropping = false});
}

final class EvadingPageSpot extends ItemPageSpot {
  final int dx;
  final int dy;
  final Offset? wobble;
  
  const EvadingPageSpot(
    super.item, 
    this.dx, 
    this.dy, 
    this.wobble,
    {super.isDropping = false}
  );
}
```

### Animation Duration Logic:
```dart
AnimatedContainer(
  duration: widget.state is ItemPageSpot && 
            (widget.state as ItemPageSpot).isDropping 
    ? Duration.zero 
    : const Duration(milliseconds: 200),
  // ... rest of properties
)
```

## Implementation Tasks
- [ ] Update PageSpotState classes to include isDropping flag
- [ ] Modify InnerPageGridItem to check flag for animation duration
- [ ] Update onItemReceive to mark items as dropping
- [ ] Add logic to clear isDropping flag after drop
- [ ] Remove unused disableAnimation state variable
- [ ] Test with various drag/drop scenarios

## Test Plan
1. Test single item drag and drop - verify no animation on drop
2. Test push chain scenarios - verify all affected items don't animate
3. Test swap scenarios - verify both swapped items don't animate
4. Test normal displacement preview - verify animations still work during drag
5. Test rapid successive drops - verify flags are properly managed

🤖 Generated with [Claude Code](https://claude.ai/code)