### PR TITLE
Fix animation failures by conditionally enabling animations based on chain consistency

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -34,6 +34,8 @@ Follow these steps to create a comprehensive architectural design:
 6. **Create Feature Branch**
    - Generate appropriate branch name (e.g., feature/component-name)
    - Use `git checkout -b` to create the branch
+   - Create an initial Commit before creating the Pull Request
+   - Switch back to master branch 
 
 7. **Create Pull Request**
    - Use `gh pr create` with comprehensive PR description


### PR DESCRIPTION
## Summary

- Fixes issue where items fail to animate when calculatePush produces different chains between preview and drop
- Conditionally sets `isDropping` based on whether chains match:
  - **Matching chains**: `isDropping: true` (instant positioning, items already in place)
  - **Different chains**: `isDropping: false` (smooth animations to new positions)
- Maintains the 200ms delay for preview animations as requested

## Problem Analysis

The current implementation always sets `isDropping: true` during drop operations, which disables animations (Duration.zero). This causes problems when:

1. **Preview chain** (cached in `_lastPushResult`) places items in certain positions
2. **Drop chain** (calculated fresh or different) would place items differently
3. **Result**: Items jump to new positions instead of animating

## Solution

Make `isDropping` conditional based on chain consistency:

```dart
// In onItemReceive
final bool chainsMatch = _lastPushResult \!= null && 
    mapEquals(_lastPushResult, pushResult);

// Use isDropping only when chains match (items already in position)
// Allow animations when chains differ (items need to move)
final bool shouldSkipAnimation = chainsMatch;
```

## Technical Design

### 1. Chain Comparison Logic

Add chain comparison in `onItemReceive` (around line 876):

```dart
// Check if we're using the cached chain or calculating fresh
final bool usingCachedChain = _lastPushResult \!= null;
final pushResult = _lastPushResult ?? _calculatePush(...);

// Determine if we should skip animations
final bool chainsMatch = usingCachedChain && 
    _lastPushResult \!= null &&
    mapEquals(_lastPushResult, pushResult);
```

### 2. Conditional isDropping

Update the push operation logic (lines 912-924):

```dart
for (final entry in pushResult.entries) {
  updateItemInNotifierMap(
    entry.key,
    ItemPageSpot(
      child: items[entry.value]\!,
      isDropping: chainsMatch, // Only skip animation if chains match
    ),
  );
}
```

Also update swap operation logic (lines 883-885):

```dart
updateItemInNotifierMap(
  oldPosition,
  ItemPageSpot(
    child: currentItem,
    isDropping: chainsMatch, // Conditional based on chain match
  ),
);
```

### 3. Animation Behavior

- **When chains match**: Items are already in preview positions, so instant placement is fine
- **When chains differ**: Items need to move to new positions, so allow smooth animations
- This provides the best user experience in both scenarios

## Implementation Tasks

- [ ] Add chain comparison logic in onItemReceive
- [ ] Store whether we're using cached chain vs fresh calculation
- [ ] Make isDropping conditional based on chain match
- [ ] Update push operation to use conditional isDropping
- [ ] Update swap operation to use conditional isDropping
- [ ] Test with matching chains (verify instant positioning)
- [ ] Test with differing chains (verify smooth animations)
- [ ] Ensure dragged item always uses appropriate animation
- [ ] Verify no visual jumps in mismatched chain scenarios
- [ ] Document the conditional animation behavior

## Test Plan

1. **Matching Chain Scenario**
   - Drag and hold in one position
   - Drop without moving
   - Verify instant positioning (no redundant animation)

2. **Differing Chain Scenario**
   - Drag to position A (preview shows displacement)
   - Quickly move to position B and drop
   - Verify smooth animations from preview positions to final positions

3. **Edge Cases**
   - Drop immediately after drag (no preview)
   - Rapid direction changes before drop
   - Multiple items in displacement chain

## Success Criteria

- When chains match: Instant positioning (current behavior)
- When chains differ: Smooth animations to correct positions
- No visual jumps or failed animations
- Maintains 200ms preview delay
- Natural, fluid user experience in all scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)