### PR TITLE
feat: continuous page navigation during drag

### DIFF
--- a/lib/nomo_pagegrid.dart
+++ b/lib/nomo_pagegrid.dart
@@ -364,9 +364,14 @@ class _NomoPageGridState extends State<_NomoPageGrid> implements PageGridControl
             listenable: Listenable.merge([
               pageGridNotifier.isDragging,
               pageGridNotifier.pageNotifier,
+              pageGridNotifier.pageCountNotifier,
             ]),
             builder: (context, child) {
-              if (pageGridNotifier.pageNotifier.value >= pageGridNotifier.maxPages - 1) {
+              final currentPage = pageGridNotifier.pageNotifier.value;
+              final totalPages = pageGridNotifier.pageCountNotifier.value;
+              final isLastPage = currentPage >= totalPages - 1;
+              
+              if (isLastPage) {
                 return SizedBox.shrink();
               }
               return AnimatedSwitcher(
@@ -394,6 +399,7 @@ class _NomoPageGridState extends State<_NomoPageGrid> implements PageGridControl
             listenable: Listenable.merge([
               pageGridNotifier.isDragging,
               pageGridNotifier.pageNotifier,
+              pageGridNotifier.pageCountNotifier,
             ]),
             builder: (context, child) {
               if (pageGridNotifier.pageNotifier.value <= 0) return SizedBox.shrink();


### PR DESCRIPTION
## Summary
- Implement continuous page navigation when dragging items to the edge of the grid viewport
- Replace one-time navigation with timer-based continuous navigation
- Add configurable delays for initial and repeat navigation

## Architecture Overview

### Current Behavior
The grid currently navigates to the next/previous page once when dragging to the edge, then stops. This limits the user's ability to move items across multiple pages smoothly.

### New Behavior
When a user drags an item to the edge and holds it there, the grid will:
1. Navigate to the next/previous page after an initial delay (600ms)
2. Continue navigating every 400ms while the item remains at the edge
3. Stop navigating when the item is moved away from the edge or reaches the first/last page

### Technical Design

#### State Management
Replace boolean flags (`_enteredRightSide`/`_enteredLeftSide`) with:
- `Timer? _edgeNavigationTimer` - Controls navigation timing
- `EdgeNavigationState? _currentEdgeState` - Tracks which edge is active
- Configurable delays for initial and repeat navigation

#### Navigation Flow
1. **Edge Detection**: 32px zones at left/right edges
2. **Hysteresis Zone**: 40px to prevent oscillation
3. **Timer Management**: Start on edge entry, cancel on exit
4. **Boundary Handling**: Auto-stop at first/last page

## API/Interface Design
No public API changes. All modifications are internal to `PageGridNotifier`.

## Data Flow
```
Drag Update → Edge Detection → Start Timer → Navigate → 
  ↑                                                      ↓
  └─────────── Check if still at edge ←─────────────────┘
```

## Tasks Checklist
- [ ] Remove boolean edge flags
- [ ] Add timer and state management fields
- [ ] Implement timer-based navigation methods
- [ ] Update onChildDragUpdate with new logic
- [ ] Add timer cleanup in dragEnded and dispose
- [ ] Test continuous navigation behavior
- [ ] Adjust timing constants for optimal UX
- [ ] Verify boundary conditions
- [ ] Test interruption scenarios

## Test Plan
1. **Basic Functionality**
   - [ ] Drag item to right edge - should navigate continuously
   - [ ] Drag item to left edge - should navigate continuously
   - [ ] Move item away from edge - should stop navigating

2. **Boundary Conditions**
   - [ ] Test at first page (left edge should not navigate)
   - [ ] Test at last page (right edge should not navigate)
   - [ ] Test navigation stops at boundaries

3. **Timing**
   - [ ] Verify initial delay (~600ms)
   - [ ] Verify repeat delay (~400ms)
   - [ ] Test smooth animation between pages

4. **Edge Cases**
   - [ ] Drag end while navigating
   - [ ] Quick edge entry/exit
   - [ ] Multiple items being dragged

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a descriptive comment to clarify the purpose of the page grid state manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->